### PR TITLE
Fix handleSectionSwitch usage

### DIFF
--- a/js/app-manager.js
+++ b/js/app-manager.js
@@ -118,7 +118,7 @@ class AppManager {
                     const section = item.dataset.section;
                     if (section) {
                         e.preventDefault();
-                        this.switchSection(section);
+                        this.handleSectionSwitch(section);
                     }
                 });
             });
@@ -165,6 +165,14 @@ class AppManager {
             console.error(`AppManager: Failed to switch to section ${section}:`, error);
             this.handleError(error, `Failed to switch to ${section} section`);
         }
+    }
+
+    /**
+     * Handle section switch events from UI elements
+     * @param {string} section - Section identifier
+     */
+    handleSectionSwitch(section) {
+        this.switchSection(section);
     }
 
     /**

--- a/tests/test-demo.js
+++ b/tests/test-demo.js
@@ -28,7 +28,7 @@ async function runTests() {
     
     try {
         // Load the demo.html file
-        const filePath = `file://${path.join(__dirname, 'demo.html')}`;
+        const filePath = `file://${path.join(__dirname, '..', 'demo.html')}`;
         console.log('Loading:', filePath);
         
         await page.goto(filePath, { waitUntil: 'networkidle0' });


### PR DESCRIPTION
## Summary
- wire up `handleSectionSwitch` in the navigation listener
- update tests to load `demo.html` from project root

## Testing
- `node tests/test-demo.js` *(fails: CORS errors when loading local scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68532ffc6eb48323ad16d0a4b9c1b937