### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,8 @@
     "axios": "^1.6.2",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
Potential fix for [https://github.com/chrisrobison/resume-tool/security/code-scanning/2](https://github.com/chrisrobison/resume-tool/security/code-scanning/2)

To mitigate the risk, a rate-limiting middleware should be added to restrict the number of requests an individual client can make to this catch-all handler within a given time frame. The most common and well-supported solution in Express is the `express-rate-limit` package. The required steps are:

- Install and import the `express-rate-limit` module.
- Create a rate limiter with suitable settings (e.g., 100 requests per 15 minutes per IP).
- Apply the rate-limiter middleware to the `app.get('*', ...)` handler, so only requests to this route are subject to rate limiting, minimizing impact on other endpoints.
- Do not otherwise alter the route's functionality.
- Add the import at the top of the file near the other imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
