### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/chrisrobison/resume-tool/security/code-scanning/1](https://github.com/chrisrobison/resume-tool/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions` block to the workflow or job(s) in `.github/workflows/cypress.yml`. This block should grant only the minimum privileges needed—the safest default is `contents: read`. For workflows that use artifact upload (such as `actions/upload-artifact`), `contents: read` is sufficient as these actions do not require write access to the repository contents.  
The best fix is to add a `permissions:` block at the job level (`cypress-run`) or at the workflow root—either is correct, but doing so at the job level allows easy future customization per job, should more jobs be added with different needs.   
Implementation steps:  
- In `.github/workflows/cypress.yml`, edit the `cypress-run` job definition to insert:
  ```yaml
  permissions:
    contents: read
  ```
  after `runs-on: ubuntu-latest` (i.e., as the first key under that job).

No additional method, import, or dependency changes are needed since this is configuration only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
